### PR TITLE
🐛 Fix: [#14] 상품 목록 페이지 기능 연결 및 리팩터링

### DIFF
--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -9,7 +9,7 @@ Pagination.propTypes = {
 };
 
 export default function Pagination({ total, limit, page, setPage }) {
-  const numPages = Math.ceil(total / limit);
+  let numPages = Math.ceil(total / limit);
 
   return (
     <S.Container>

--- a/src/components/ProductBlock/index.js
+++ b/src/components/ProductBlock/index.js
@@ -10,7 +10,7 @@ export default function ProductBlock({ data }) {
   const navigate = useNavigate();
 
   return (
-    <S.ProductRow onClick={() => navigate(`${data.id}`)}>
+    <S.ProductRow onClick={() => navigate(`/productdetail/${data.id}`)}>
       <S.ImgCol>
         <img src={data.imgUrl[0]} />
       </S.ImgCol>

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export const usePagination = () => {
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const offset = (page - 1) * limit;
+
+  return { page, limit, offset, setPage };
+};

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import * as S from './style';
 import {
   Navigation,
@@ -7,12 +6,14 @@ import {
   Pagination,
   Footer,
 } from 'components';
-import { dummies } from 'constants/dummy';
+import { useRecoilValue } from 'recoil';
+import { productState } from 'recoil/product';
+import { usePagination } from 'hooks/usePagination';
 
 export default function MainPage() {
-  const [boardData, setBoardData] = useState(dummies);
-  const [page, setPage] = useState(1);
-  const offset = (page - 1) * 10;
+  const boardData = useRecoilValue(productState);
+  const filteredBoard = boardData.filter(item => item.sale);
+  const { page, setPage, limit, offset } = usePagination();
 
   return (
     <>
@@ -32,14 +33,14 @@ export default function MainPage() {
       <S.Container>
         <div>
           <span>FRUITTE STORE</span>
-          <span>{boardData.length}</span>
+          <span>{filteredBoard.length}</span>
         </div>
-        {boardData.slice(offset, offset + 10).map(item => (
-          <ProductBlock data={item} key={item.id} />
-        ))}
+        {filteredBoard
+          .slice(offset, offset + limit)
+          .map(item => item.sale && <ProductBlock data={item} key={item.id} />)}
         <Pagination
-          total={boardData.length}
-          limit={10}
+          total={filteredBoard.length}
+          limit={limit}
           page={page}
           setPage={setPage}
         />


### PR DESCRIPTION
## 요약

- 상품 목록 페이지 리코일 연결
- 페이지네이션 리코일 데이터 따라 갱신 가능하도록 변경
- 페이지네이션 훅 함수 추가

## 관련 커밋

- Related: #14 